### PR TITLE
修复 main 分支自动发布 Release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Resolve release tag
         id: release
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         shell: pwsh
         run: |
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
@@ -66,20 +66,28 @@ jobs:
             if ([string]::IsNullOrWhiteSpace($tag)) {
               $tag = "build-${{ github.run_number }}"
             }
+          } elseif ("${{ github.ref }}" -eq "refs/heads/main") {
+            $tag = "build-${{ github.run_number }}"
           } else {
             $tag = "${{ github.ref_name }}"
           }
           "tag=$tag" >> $env:GITHUB_OUTPUT
 
       - name: Publish GitHub release
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           $tag = "${{ steps.release.outputs.tag }}"
-          gh release create $tag ".\poe2-economy-display-mod.zip" `
-            --repo "${{ github.repository }}" `
-            --title "poe2-economy-display-mod $tag" `
-            --notes "Automated build from ${{ github.sha }}." `
-            --latest
+          $repo = "${{ github.repository }}"
+          gh release view $tag --repo $repo *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $tag ".\poe2-economy-display-mod.zip" --repo $repo --clobber
+          } else {
+            gh release create $tag ".\poe2-economy-display-mod.zip" `
+              --repo $repo `
+              --title "poe2-economy-display-mod $tag" `
+              --notes "Automated build from ${{ github.sha }}." `
+              --latest
+          }

--- a/agent/build/2026-06-19-添加GitHubActions发布打包.md
+++ b/agent/build/2026-06-19-添加GitHubActions发布打包.md
@@ -8,7 +8,9 @@
 - workflow 使用 `windows-latest` 和 `.NET 8.x`，调用现有 `build/make_release.ps1 -SkipDoc` 生成发布版。
 - 构建完成后将 `发布版/物价补丁` 压缩为 `poe2-economy-display-mod.zip`。
 - 通过 `actions/upload-artifact@v4` 上传发布包，供没有本地 Windows 构建环境时下载使用。
-- workflow 在手动运行或推送 `v*` tag 时会创建 GitHub Release，并上传 `poe2-economy-display-mod.zip`。
+- workflow 在手动运行、推送 `v*` tag 或推送到 `main` 时会创建 GitHub Release，并上传 `poe2-economy-display-mod.zip`。
+- `main` 推送和未填写 tag 的手动运行使用 `build-<run-number>` 作为 release tag；如果 release 已存在，会覆盖上传 zip，方便重跑 workflow。
+- `push main` 触发自动发布时保留 `paths` 限制，只在 `.github/workflows/build-release.yml`、`build/**`、`物价补丁/**`、`restore-seeds/**` 变更时运行；README、agent 记录等纯文案改动不会触发打包发布。
 - README 顶部 `26/6/19 更新` 不展示发布构建流程，相关内容仅保留在 agent 记录和 workflow 中。
 
 ## 变更原因


### PR DESCRIPTION
@weixiao030 这个 PR 只涉及一个改动：修复 main 分支自动发布 Release。

## 变更内容
- 合并到 main 后，自动发布步骤也会执行，不再只上传 artifact。
- main 分支自动发布使用 build-<run-number> 作为 release tag。
- workflow 重跑时如果 release 已存在，会覆盖上传 zip，避免重复 tag 导致失败。
- 保留 paths 限制，README、agent 记录等纯文案改动不会触发打包发布。

## 背景
之前 PR 合并后 workflow 能成功 build，但 Resolve release tag 和 Publish GitHub release 被条件跳过，导致 Release 页面没有发布包。